### PR TITLE
feat: Implement custom Compose Image Picker library

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -49,6 +49,8 @@ dependencies {
     implementation(libs.androidx.ui.graphics)
     implementation(libs.androidx.ui.tooling.preview)
     implementation(libs.androidx.material3)
+    implementation(project(":imagepicker"))
+    implementation("io.coil-kt:coil-compose:2.4.0") // Added Coil for image previews
     testImplementation(libs.junit)
     androidTestImplementation(libs.androidx.junit)
     androidTestImplementation(libs.androidx.espresso.core)

--- a/app/src/main/java/com/example/jules/MainActivity.kt
+++ b/app/src/main/java/com/example/jules/MainActivity.kt
@@ -1,29 +1,50 @@
+// Updated MainActivity for ImagePicker demonstration
 package com.example.jules
 
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.material3.Scaffold
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.LazyRow
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.Button
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import coil.compose.AsyncImage
+import com.example.imagepicker.ImagePicker // Import from the library
+import com.example.imagepicker.ImageModel // Import from the library
 import com.example.jules.ui.theme.JulesTheme
 
 class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        enableEdgeToEdge()
+        enableEdgeToEdge() // Keep if it was there
         setContent {
             JulesTheme {
-                Scaffold(modifier = Modifier.fillMaxSize()) { innerPadding ->
-                    Greeting(
-                        name = "Android",
-                        modifier = Modifier.padding(innerPadding)
-                    )
+                Surface( // Use Surface as a general container
+                    modifier = Modifier.fillMaxSize(),
+                    color = MaterialTheme.colorScheme.background
+                ) {
+                    ImagePickerSampleScreen()
                 }
             }
         }
@@ -31,17 +52,61 @@ class MainActivity : ComponentActivity() {
 }
 
 @Composable
-fun Greeting(name: String, modifier: Modifier = Modifier) {
-    Text(
-        text = "Hello $name!",
+fun ImagePickerSampleScreen(modifier: Modifier = Modifier) {
+    var showImagePicker by remember { mutableStateOf(false) }
+    var selectedImagesFromPicker by remember { mutableStateOf<List<ImageModel>>(emptyList()) }
+
+    Column(
         modifier = modifier
-    )
+            .fillMaxSize()
+            .padding(16.dp), // Padding for the content
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.Center // Center content vertically
+    ) {
+        Button(onClick = { showImagePicker = true }) {
+            Text("Open Image Picker")
+        }
+
+        Spacer(modifier = Modifier.height(16.dp))
+
+        if (selectedImagesFromPicker.isNotEmpty()) {
+            Text("Selected Images (${selectedImagesFromPicker.size}):", style = MaterialTheme.typography.titleMedium)
+            Spacer(modifier = Modifier.height(8.dp))
+            LazyRow(
+                modifier = Modifier.fillMaxWidth().height(120.dp),
+                horizontalArrangement = Arrangement.spacedBy(8.dp),
+                contentPadding = PaddingValues(vertical = 8.dp)
+            ) {
+                items(selectedImagesFromPicker) { imageModel ->
+                    AsyncImage(
+                        model = imageModel.uri,
+                        contentDescription = "Selected Image",
+                        modifier = Modifier.size(100.dp) // Fixed size for previews
+                    )
+                }
+            }
+        } else {
+            Text("No images selected yet.", style = MaterialTheme.typography.bodyMedium)
+        }
+    }
+
+    // This part handles the ImagePicker overlay
+    if (showImagePicker) {
+        // The ImagePicker will be composed on top of the current screen content
+        // It should handle its own background and full-screen presentation if needed.
+        ImagePicker(
+            onImagesSelected = { images ->
+                selectedImagesFromPicker = images
+                showImagePicker = false // Hide picker after selection
+            }
+        )
+    }
 }
 
 @Preview(showBackground = true)
 @Composable
-fun GreetingPreview() {
+fun DefaultPreview() { // Renamed preview function to avoid conflict if GreetingPreview existed
     JulesTheme {
-        Greeting("Android")
+        ImagePickerSampleScreen()
     }
 }

--- a/imagepicker/build.gradle.kts
+++ b/imagepicker/build.gradle.kts
@@ -1,0 +1,53 @@
+plugins {
+    id("com.android.library")
+    id("org.jetbrains.kotlin.android")
+}
+
+android {
+    namespace = "com.example.imagepicker"
+    compileSdk = 34
+
+    defaultConfig {
+        minSdk = 24
+        targetSdk = 34
+
+        testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
+        consumerProguardFiles("consumer-rules.pro")
+    }
+
+    buildTypes {
+        release {
+            isMinifyEnabled = false
+            proguardFiles(getDefaultProguardFile("proguard-android-optimize.txt"), "proguard-rules.pro")
+        }
+    }
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_1_8
+        targetCompatibility = JavaVersion.VERSION_1_8
+    }
+    kotlinOptions {
+        jvmTarget = "1.8"
+    }
+    buildFeatures {
+        compose = true
+    }
+    composeOptions {
+        kotlinCompilerExtensionVersion = "1.5.1"
+    }
+}
+
+dependencies {
+    implementation("androidx.core:core-ktx:1.9.0")
+    implementation("androidx.appcompat:appcompat:1.6.1")
+    implementation("com.google.android.material:material:1.8.0")
+    implementation("androidx.compose.ui:ui:1.5.4")
+    implementation("androidx.compose.foundation:foundation:1.5.4")
+    implementation("androidx.compose.material:material:1.5.4")
+    implementation("io.coil-kt:coil-compose:2.4.0")
+    testImplementation("junit:junit:4.13.2")
+    testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:1.7.3")
+    testImplementation("io.mockk:mockk:1.13.5")
+    // androidTestImplementation("androidx.compose.ui:ui-test-junit4:1.5.4") // As per instruction, skipping for now
+    androidTestImplementation("androidx.test.ext:junit:1.1.5")
+    androidTestImplementation("androidx.test.espresso:espresso-core:3.5.1")
+}

--- a/imagepicker/consumer-rules.pro
+++ b/imagepicker/consumer-rules.pro
@@ -1,0 +1,16 @@
+# Add project specific ProGuard rules here.
+# By default, the flags in this file are appended to flags specified
+# in AndroidManifest.xml
+# You can edit this file to add library specific rules that apply to the
+# library consumers. (Users who build their apps with this library)
+#
+# Rules specified in this file are applied by the Android Gradle plugin
+# to the library module, and are merged into the consuming project's
+# ProGuard configuration.
+#
+# https://developer.android.com/studio/build/shrink-code#keep-code
+#
+# -keep class com.example.MyClass {
+#   public <fields>;
+#   public <methods>;
+# }

--- a/imagepicker/proguard-rules.pro
+++ b/imagepicker/proguard-rules.pro
@@ -1,0 +1,9 @@
+# Add specific rules for ProGuard here.
+# You can disable code shrinking by adding the following rule:
+# -dontshrink
+#
+# You can enable code obfuscation by adding the following rule:
+# -dontobfuscate
+#
+# For more information, see:
+# https://www.guardsquare.com/manual/configuration/usage

--- a/imagepicker/src/main/AndroidManifest.xml
+++ b/imagepicker/src/main/AndroidManifest.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <uses-permission android:name="android.permission.READ_MEDIA_IMAGES" />
+    <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" android:maxSdkVersion="32" />
+
+</manifest>

--- a/imagepicker/src/main/java/com/example/imagepicker/ImageModel.kt
+++ b/imagepicker/src/main/java/com/example/imagepicker/ImageModel.kt
@@ -1,0 +1,5 @@
+package com.example.imagepicker
+
+import android.net.Uri
+
+data class ImageModel(val uri: Uri)

--- a/imagepicker/src/main/java/com/example/imagepicker/ImagePicker.kt
+++ b/imagepicker/src/main/java/com/example/imagepicker/ImagePicker.kt
@@ -1,0 +1,226 @@
+package com.example.imagepicker
+
+import android.Manifest
+import android.content.ContentUris
+import android.content.Intent
+import android.content.pm.PackageManager
+import android.net.Uri
+import android.os.Build
+import android.provider.MediaStore
+import android.provider.Settings
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.grid.GridCells
+import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
+import androidx.compose.foundation.lazy.grid.items
+import androidx.compose.material.Button
+import androidx.compose.material.Text
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalLifecycleOwner
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.core.content.ContextCompat
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleEventObserver
+import coil.compose.rememberAsyncImagePainter
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+
+@Composable
+fun ImagePicker(onImagesSelected: (List<ImageModel>) -> Unit) {
+    val context = LocalContext.current
+    val images = remember { mutableStateOf<List<ImageModel>>(emptyList()) }
+    val selectedImages = remember { mutableStateOf<Set<Uri>>(emptySet()) }
+
+    val permission = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+        Manifest.permission.READ_MEDIA_IMAGES
+    } else {
+        Manifest.permission.READ_EXTERNAL_STORAGE
+    }
+
+    var permissionGranted by remember {
+        mutableStateOf(
+            ContextCompat.checkSelfPermission(context, permission) == PackageManager.PERMISSION_GRANTED
+        )
+    }
+
+    // To track if the user has denied permission at least once (and thus we should show rationale)
+    // This is a simplification; a more robust solution might use LocalInspectionMode.current
+    // or check shouldShowRequestPermissionRationale which is not directly available in Composable side-effect.
+    var permissionRequestedPreviously by remember { mutableStateOf(false) }
+    var showSettingsButton by remember { mutableStateOf(false) }
+
+
+    val permissionLauncher = rememberLauncherForActivityResult(
+        ActivityResultContracts.RequestPermission()
+    ) { isGranted: Boolean ->
+        permissionGranted = isGranted
+        if (!isGranted) {
+            // If denied, and requested previously, it might be permanently denied.
+            // This logic is a bit simplified. A real app might use Activity.shouldShowRequestPermissionRationale
+            // or a more complex state to determine if it's "permanently denied".
+            if (permissionRequestedPreviously) {
+                 showSettingsButton = true
+            }
+            permissionRequestedPreviously = true
+        } else {
+            // Reset flags if permission is granted
+            permissionRequestedPreviously = false
+            showSettingsButton = false
+        }
+    }
+
+    // Handle lifecycle events to re-check permission when app comes to foreground
+    // This is important if the user grants permission from settings
+     LocalLifecycleOwner.current.lifecycle.addObserver(remember {
+        LifecycleEventObserver { _, event ->
+            if (event == Lifecycle.Event.ON_RESUME) {
+                val newPermissionStatus = ContextCompat.checkSelfPermission(context, permission) == PackageManager.PERMISSION_GRANTED
+                if (newPermissionStatus != permissionGranted) {
+                    permissionGranted = newPermissionStatus
+                    if (newPermissionStatus) {
+                        // If permission granted from settings, hide the settings button and reset flags
+                        showSettingsButton = false
+                        permissionRequestedPreviously = false
+                    }
+                }
+            }
+        }
+    })
+
+
+    LaunchedEffect(permissionGranted) { // React to changes in permissionGranted
+        if (permissionGranted) {
+            withContext(Dispatchers.IO) {
+                val projection = arrayOf(
+                    MediaStore.Images.Media._ID,
+                    MediaStore.Images.Media.DISPLAY_NAME // Though not used, good to have
+                )
+                val cursor = context.contentResolver.query(
+                    MediaStore.Images.Media.EXTERNAL_CONTENT_URI,
+                    projection,
+                    null,
+                    null,
+                    "${MediaStore.Images.Media.DATE_ADDED} DESC"
+                )
+                val imageList = mutableListOf<ImageModel>()
+                cursor?.use {
+                    val idColumn = it.getColumnIndexOrThrow(MediaStore.Images.Media._ID)
+                    while (it.moveToNext()) {
+                        val id = it.getLong(idColumn)
+                        val contentUri = ContentUris.withAppendedId(
+                            MediaStore.Images.Media.EXTERNAL_CONTENT_URI,
+                            id
+                        )
+                        imageList.add(ImageModel(contentUri))
+                    }
+                }
+                images.value = imageList
+            }
+        } else {
+            images.value = emptyList() // Clear images if permission is revoked
+        }
+    }
+
+    Column(modifier = Modifier.fillMaxSize()) {
+        if (permissionGranted) {
+            if (images.value.isEmpty()) {
+                Box(modifier = Modifier.fillMaxSize().weight(1f), contentAlignment = Alignment.Center) {
+                    Text("No images found or an error occurred.")
+                }
+            } else {
+                LazyVerticalGrid(
+                    columns = GridCells.Fixed(3),
+                    modifier = Modifier.weight(1f),
+                    contentPadding = PaddingValues(4.dp),
+                    verticalArrangement = Arrangement.spacedBy(4.dp),
+                    horizontalArrangement = Arrangement.spacedBy(4.dp)
+                ) {
+                    items(images.value, key = { it.uri }) { image ->
+                        val isSelected = selectedImages.value.contains(image.uri)
+                        Image(
+                            painter = rememberAsyncImagePainter(model = image.uri),
+                            contentDescription = "Image",
+                            modifier = Modifier
+                                .aspectRatio(1f)
+                                .border(
+                                    width = if (isSelected) 4.dp else 0.dp,
+                                    color = if (isSelected) Color.Blue else Color.Transparent
+                                )
+                                .clickable {
+                                    val currentSelected = selectedImages.value.toMutableSet()
+                                    if (isSelected) {
+                                        currentSelected.remove(image.uri)
+                                    } else {
+                                        currentSelected.add(image.uri)
+                                    }
+                                    selectedImages.value = currentSelected
+                                },
+                            contentScale = ContentScale.Crop
+                        )
+                    }
+                }
+            }
+        } else {
+            // Permission not granted UI
+            Box(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .weight(1f)
+                    .padding(16.dp),
+                contentAlignment = Alignment.Center
+            ) {
+                Column(horizontalAlignment = Alignment.CenterHorizontally) {
+                    Text(
+                        "Storage permission is required to load images.",
+                        textAlign = TextAlign.Center,
+                        modifier = Modifier.padding(bottom = 8.dp)
+                    )
+                    if (showSettingsButton) {
+                        Text(
+                            "Permission has been denied. Please enable it in app settings.",
+                            textAlign = TextAlign.Center,
+                            modifier = Modifier.padding(bottom = 16.dp)
+                        )
+                        Button(onClick = {
+                            val intent = Intent(Settings.ACTION_APPLICATION_DETAILS_SETTINGS)
+                            intent.data = Uri.fromParts("package", context.packageName, null)
+                            context.startActivity(intent)
+                        }) {
+                            Text("Open Settings")
+                        }
+                    } else {
+                        Button(onClick = {
+                             permissionRequestedPreviously = true // Mark that we've now requested it
+                            permissionLauncher.launch(permission)
+                        }) {
+                            Text("Grant Permission")
+                        }
+                    }
+                }
+            }
+        }
+
+        Button(
+            onClick = {
+                val result = images.value.filter { selectedImages.value.contains(it.uri) }
+                onImagesSelected(result)
+            },
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(16.dp),
+            enabled = selectedImages.value.isNotEmpty() && permissionGranted
+        ) {
+            Text("Done (${selectedImages.value.size})")
+        }
+    }
+}

--- a/imagepicker/src/test/java/com/example/imagepicker/ImagePickerLogicTest.kt
+++ b/imagepicker/src/test/java/com/example/imagepicker/ImagePickerLogicTest.kt
@@ -1,0 +1,78 @@
+package com.example.imagepicker
+
+import android.net.Uri
+import androidx.compose.runtime.mutableStateOf
+import io.mockk.mockk
+import io.mockk.verify
+import org.junit.Assert.*
+import org.junit.Test
+
+class ImagePickerLogicTest {
+
+    @Test
+    fun `test image selection and deselection`() {
+        // This test directly manipulates a state holder similar to how the Composable would.
+        // It's a way to unit test the selection logic itself.
+        val selectedImagesState = mutableStateOf<Set<Uri>>(emptySet())
+
+        val testUri1 = Uri.parse("content://media/external/images/media/1")
+        val testUri2 = Uri.parse("content://media/external/images/media/2")
+
+        // Simulate selecting image 1
+        selectedImagesState.value = selectedImagesState.value + testUri1
+        assertTrue("testUri1 should be selected", selectedImagesState.value.contains(testUri1))
+        assertEquals("Size of selected set should be 1", 1, selectedImagesState.value.size)
+
+        // Simulate selecting image 2
+        selectedImagesState.value = selectedImagesState.value + testUri2
+        assertTrue("testUri2 should be selected", selectedImagesState.value.contains(testUri2))
+        assertEquals("Size of selected set should be 2", 2, selectedImagesState.value.size)
+
+        // Simulate selecting image 1 again (should have no effect as it's a Set)
+        selectedImagesState.value = selectedImagesState.value + testUri1
+        assertEquals("Size of selected set should still be 2", 2, selectedImagesState.value.size)
+
+        // Simulate deselecting image 1
+        selectedImagesState.value = selectedImagesState.value - testUri1
+        assertFalse("testUri1 should be deselected", selectedImagesState.value.contains(testUri1))
+        assertTrue("testUri2 should still be selected", selectedImagesState.value.contains(testUri2))
+        assertEquals("Size of selected set should be 1", 1, selectedImagesState.value.size)
+
+        // Simulate deselecting image 2
+        selectedImagesState.value = selectedImagesState.value - testUri2
+        assertFalse("testUri2 should be deselected", selectedImagesState.value.contains(testUri2))
+        assertTrue("Selected set should be empty", selectedImagesState.value.isEmpty())
+    }
+
+    @Test
+    fun `onImagesSelected callback provides correct models`() {
+        // Mock the necessary data and callback
+        val testUri1 = Uri.parse("content://media/external/images/media/1")
+        val testUri2 = Uri.parse("content://media/external/images/media/2")
+        val testUri3 = Uri.parse("content://media/external/images/media/3")
+
+        val allImageModels = listOf(
+            ImageModel(testUri1),
+            ImageModel(testUri2),
+            ImageModel(testUri3)
+        )
+        val selectedUris = setOf(testUri1, testUri3)
+
+        // This lambda will be our mock callback
+        val onImagesSelectedCallback: (List<ImageModel>) -> Unit = mockk(relaxed = True)
+
+        // Logic that would be in the "Done" button's onClick
+        val resultModels = allImageModels.filter { selectedUris.contains(it.uri) }
+        onImagesSelectedCallback(resultModels)
+
+        // Verify the callback was called with the correct list of ImageModels
+        val expectedSelectedModels = listOf(ImageModel(testUri1), ImageModel(testUri3))
+        verify { onImagesSelectedCallback(expectedSelectedModels) }
+    }
+
+     @Test
+    fun `initial state of selectedImages is empty`() {
+        val selectedImagesState = mutableStateOf<Set<Uri>>(emptySet())
+        assertTrue("Initially, selectedImages set should be empty", selectedImagesState.value.isEmpty())
+    }
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -21,3 +21,4 @@ dependencyResolutionManagement {
 
 rootProject.name = "Jules"
 include(":app")
+include(":imagepicker")


### PR DESCRIPTION
This commit introduces a new custom image picker library built with Jetpack Compose.

Features:
- New library module `imagepicker` containing the picker logic.
- Composable `ImagePicker` that displays images from device storage in a grid.
- Allows selection of multiple images.
- Handles `READ_MEDIA_IMAGES` / `READ_EXTERNAL_STORAGE` permissions, including runtime requests and graceful denial.
- Returns selected image URIs via a callback.
- Unit tests for selection logic and callback data.

The `app` module includes a sample screen (`ImagePickerSampleScreen`) demonstrating how to integrate and use the `ImagePicker`. Selected images are previewed using Coil.